### PR TITLE
temp: remove inbound campaign PIN authentication

### DIFF
--- a/packages/backend/campaign/campaign_handler.py
+++ b/packages/backend/campaign/campaign_handler.py
@@ -5,7 +5,7 @@ import logging
 import os
 from decimal import Decimal
 from botocore.exceptions import ClientError
-from utils import lambda_response, parse_body, get_timestamp, generate_id, convert_decimal_to_int, serialize_dynamodb_item, build_update_expression, hash_campaign_pin
+from utils import lambda_response, parse_body, get_timestamp, generate_id, convert_decimal_to_int, serialize_dynamodb_item, build_update_expression
 
 # Configure logging
 logger = logging.getLogger()
@@ -39,14 +39,6 @@ def create_campaign(event, context):
         end_date = body['endDate']
         owner_id = body['ownerId']
         campaign_type = body.get('campaignType', 'outbound')
-        campaign_pin = body.get('campaignPin', '')
-
-        # 인바운드 캠페인은 PIN 필수 + 6자리 숫자 검증
-        if campaign_type == 'inbound':
-            pin_clean = str(campaign_pin).strip()
-            if not pin_clean.isdigit() or len(pin_clean) != 6:
-                return lambda_response(400, {'error': 'Inbound campaign requires a 6-digit PIN'})
-            campaign_pin = pin_clean
         
         # Validate date range
         if start_date >= end_date:
@@ -90,10 +82,6 @@ def create_campaign(event, context):
             'GSI1SK': f'CAMPAIGN#{timestamp}'
         }
 
-        # 인바운드 캠페인: PIN을 salted HMAC으로 해시 저장 (평문 저장 금지)
-        if campaign_type == 'inbound' and campaign_pin:
-            campaign_record['campaignPinHash'] = hash_campaign_pin(campaign_pin, campaign_id)
-        
         campaigns_table = dynamodb.Table(CAMPAIGNS_TABLE)
         
         # Check if campaign code already exists using the CampaignCodeIndex
@@ -272,16 +260,8 @@ def update_campaign(event, context):
         body = parse_body(event)
         
         # Validate that at least one field is provided for update
-        updatable_fields = ['campaignName', 'campaignCode', 'description', 'startDate', 'endDate', 'ownerId', 'status', 'campaignPin', 'agentConfigurations']
+        updatable_fields = ['campaignName', 'campaignCode', 'description', 'startDate', 'endDate', 'ownerId', 'status', 'agentConfigurations']
         update_data = {k: v for k, v in body.items() if k in updatable_fields and v is not None}
-
-        # 인바운드 캠페인 PIN 변경 시: 검증 후 해시로 변환하여 저장 (평문 저장 금지)
-        if 'campaignPin' in update_data:
-            pin = str(update_data['campaignPin']).strip()
-            if not pin.isdigit() or len(pin) != 6:
-                return lambda_response(400, {'error': 'campaignPin must be exactly 6 digits'})
-            update_data['campaignPinHash'] = hash_campaign_pin(pin, campaign_id)
-            del update_data['campaignPin']
         
         if not update_data:
             return lambda_response(400, {'error': 'No valid fields provided for update'})

--- a/packages/backend/session/inbound_session_handler.py
+++ b/packages/backend/session/inbound_session_handler.py
@@ -12,7 +12,6 @@ from botocore.exceptions import ClientError
 from utils import (
     lambda_response, parse_body, get_timestamp,
     generate_session_id, get_ttl_timestamp, generate_csrf_token,
-    secure_compare, hash_campaign_pin,
 )
 
 logger = logging.getLogger()
@@ -113,9 +112,8 @@ def create_inbound_session(event, context):
     customer_email = (body.get('customerEmail') or '').strip()
     customer_company = (body.get('customerCompany') or '').strip()
     customer_phone = (body.get('customerPhone') or '').strip()
-    pin_input = (body.get('pinNumber') or '').strip()
 
-    if not all([customer_name, customer_email, customer_company, customer_phone, pin_input]):
+    if not all([customer_name, customer_email, customer_company, customer_phone]):
         return lambda_response(400, {'error': 'Missing required fields'})
 
     # 입력값 길이 제한 (DoS 방어)
@@ -133,13 +131,13 @@ def create_inbound_session(event, context):
 
     return _create_inbound_session_inner(
         campaign_code, customer_name, customer_email,
-        customer_company, customer_phone, pin_input,
+        customer_company, customer_phone,
     )
 
 
 def _create_inbound_session_inner(
     campaign_code, customer_name, customer_email,
-    customer_company, customer_phone, pin_input,
+    customer_company, customer_phone,
 ):
     """인바운드 세션 생성 내부 로직 - 복잡도 분리."""
     try:
@@ -150,26 +148,6 @@ def _create_inbound_session_inner(
             return lambda_response(403, {'error': 'Campaign is not active'})
 
         campaign_id = campaign['campaignId']
-
-        # PIN 검증: 해시 우선, 평문 fallback (마이그레이션 호환)
-        stored_hash = campaign.get('campaignPinHash', '')
-        if stored_hash:
-            input_hash = hash_campaign_pin(pin_input, campaign_id)
-            logger.info(
-                f"PIN verify (hashed) campaign={campaign_id} "
-                f"input_hash_prefix={input_hash[:8]} stored_hash_prefix={stored_hash[:8]}"
-            )
-            if not secure_compare(input_hash, stored_hash):
-                return lambda_response(401, {'error': 'Invalid PIN'})
-        else:
-            # 레거시: 해시가 아직 없는 캠페인은 평문 비교
-            legacy_pin = campaign.get('campaignPin', '')
-            logger.info(
-                f"PIN verify (legacy) campaign={campaign_id} "
-                f"has_legacy_pin={bool(legacy_pin)}"
-            )
-            if not legacy_pin or not secure_compare(pin_input, legacy_pin):
-                return lambda_response(401, {'error': 'Invalid PIN'})
 
         phone_normalized = _normalize_phone(customer_phone)
 

--- a/packages/backend/websocket/websocket_handler.py
+++ b/packages/backend/websocket/websocket_handler.py
@@ -10,7 +10,7 @@ import json
 import boto3
 import os
 from datetime import datetime, timezone, timedelta
-from utils import get_timestamp, generate_id, get_ttl_timestamp, secure_compare, hash_campaign_pin
+from utils import get_timestamp, generate_id, get_ttl_timestamp
 from agent_runtime import AgentCoreClient, get_agent_config_for_session
 
 dynamodb = boto3.resource('dynamodb')
@@ -22,35 +22,6 @@ agentcore_client = AgentCoreClient()
 
 # Div Return Protocol: contentType 감지 마커
 DIV_RETURN_MARKER = '<div class="prechat-form" data-form-type="div-return">'
-
-CAMPAIGNS_TABLE = os.environ.get('CAMPAIGNS_TABLE')
-
-
-def _verify_inbound_pin(pin_input: str, campaign_id: str) -> bool:
-    """인바운드 캠페인 PIN 검증 (해시 우선, 평문 fallback)."""
-    if not campaign_id or not pin_input:
-        return False
-    try:
-        campaigns_table = dynamodb.Table(CAMPAIGNS_TABLE)
-        resp = campaigns_table.get_item(
-            Key={'PK': f'CAMPAIGN#{campaign_id}', 'SK': 'METADATA'},
-            ProjectionExpression='campaignPinHash, campaignPin',
-        )
-        item = resp.get('Item')
-        if not item:
-            return False
-
-        stored_hash = item.get('campaignPinHash', '')
-        if stored_hash:
-            input_hash = hash_campaign_pin(pin_input, campaign_id)
-            return secure_compare(input_hash, stored_hash)
-
-        # 레거시 평문 fallback
-        legacy_pin = item.get('campaignPin', '')
-        return bool(legacy_pin) and secure_compare(pin_input, legacy_pin)
-    except Exception as e:
-        print(f"[ERROR] _verify_inbound_pin: {e}")
-        return False
 
 
 def handle_connect(event, context):
@@ -82,11 +53,6 @@ def handle_connect(event, context):
         print(f"WebSocket 연결 거부 - sessionId 누락")
         return {'statusCode': 403}
 
-    # pin 또는 token 중 하나는 필수
-    if not pin and not token:
-        print(f"WebSocket 연결 거부 - 인증 파라미터 누락 (pin 또는 token 필요)")
-        return {'statusCode': 403}
-
     try:
         sessions_table = dynamodb.Table(SESSIONS_TABLE)
 
@@ -106,7 +72,7 @@ def handle_connect(event, context):
                 print(f"WebSocket 연결 거부 - 세션 미존재: {session_id}")
                 return {'statusCode': 403}
 
-        # PIN 인증 (고객용 — outbound/inbound 공통)
+        # 고객용 인증 (outbound: PIN 필수, inbound: PIN 불필요)
         else:
             session_resp = sessions_table.get_item(
                 Key={'PK': f'SESSION#{session_id}', 'SK': 'METADATA'}
@@ -119,13 +85,13 @@ def handle_connect(event, context):
             campaign_type = session.get('campaignType', 'outbound')
 
             if campaign_type == 'inbound':
-                # 인바운드: 캠페인 PIN 해시와 비교
-                campaign_id = session.get('campaignId', '')
-                if not _verify_inbound_pin(pin, campaign_id):
-                    print(f"WebSocket 연결 거부 - 인바운드 PIN 불일치: {session_id}")
-                    return {'statusCode': 403}
+                # 인바운드: sessionId + active 상태만 확인 (PIN 불필요)
+                pass
             else:
-                # 아웃바운드: 세션 PIN과 비교
+                # 아웃바운드: 세션 PIN과 비교 (기존 유지)
+                if not pin:
+                    print(f"WebSocket 연결 거부 - 아웃바운드 PIN 누락: {session_id}")
+                    return {'statusCode': 403}
                 stored_pin = session.get('pinNumber', '')
                 if pin != stored_pin:
                     print(f"WebSocket 연결 거부 - 아웃바운드 PIN 불일치: {session_id}")

--- a/packages/web-app/src/hooks/useWebSocket.ts
+++ b/packages/web-app/src/hooks/useWebSocket.ts
@@ -118,7 +118,7 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
 
   // WebSocket 연결 수립
   const connect = useCallback(() => {
-    if (!wsUrl || !sessionId || !pin) return
+    if (!wsUrl || !sessionId) return
     if (wsRef.current?.readyState === WebSocket.OPEN) return
 
     // 기존 연결 정리
@@ -131,7 +131,10 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
     setConnectionState('connecting')
     isIntentionalCloseRef.current = false
 
-    const url = `${wsUrl}?sessionId=${encodeURIComponent(sessionId)}&pin=${encodeURIComponent(pin)}`
+    let url = `${wsUrl}?sessionId=${encodeURIComponent(sessionId)}`
+    if (pin) {
+      url += `&pin=${encodeURIComponent(pin)}`
+    }
     const ws = new WebSocket(url)
 
     ws.onopen = () => {

--- a/packages/web-app/src/pages/admin/CampaignDetails.tsx
+++ b/packages/web-app/src/pages/admin/CampaignDetails.tsx
@@ -14,8 +14,6 @@ import {
   ButtonDropdown,
   Modal,
   CopyToClipboard,
-  Input,
-  FormField,
   Grid
 } from '@cloudscape-design/components'
 import QRCode from 'qrcode'
@@ -46,11 +44,6 @@ export default function CampaignDetails() {
   const [deleting, setDeleting] = useState(false)
   const [activeTabId, setActiveTabId] = useState('analytics')
   const qrCanvasRef = useRef<HTMLCanvasElement>(null)
-  const [showPinInput, setShowPinInput] = useState(false)
-  const [newPin, setNewPin] = useState('')
-  const [pinError, setPinError] = useState('')
-  const [pinSaving, setPinSaving] = useState(false)
-  const [pinMessage, setPinMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
 
   const isInbound = campaign?.campaignType === 'inbound'
   const inboundUrl = isInbound && campaign
@@ -88,27 +81,6 @@ export default function CampaignDetails() {
     link.download = `qr-${safeName}.png`
     link.href = canvas.toDataURL('image/png')
     link.click()
-  }
-
-  const handleSavePin = async () => {
-    if (!/^\d{6}$/.test(newPin)) {
-      setPinError(t('inboundDetails.access.pinFormatError'))
-      return
-    }
-    if (!campaignId) return
-    setPinError('')
-    setPinSaving(true)
-    setPinMessage(null)
-    try {
-      await campaignApi.updateCampaign(campaignId, { campaignPin: newPin })
-      setPinMessage({ type: 'success', text: t('inboundDetails.access.pinSaved') })
-      setShowPinInput(false)
-      setNewPin('')
-    } catch (err: any) {
-      setPinMessage({ type: 'error', text: err.message || t('inboundDetails.access.pinSaveFailed') })
-    } finally {
-      setPinSaving(false)
-    }
   }
 
   const loadCampaignData = async () => {
@@ -325,16 +297,6 @@ export default function CampaignDetails() {
                     {t('inboundDetails.access.description')}
                   </Alert>
 
-                  {pinMessage && (
-                    <Alert
-                      type={pinMessage.type}
-                      dismissible
-                      onDismiss={() => setPinMessage(null)}
-                    >
-                      {pinMessage.text}
-                    </Alert>
-                  )}
-
                   <Grid
                     gridDefinition={[
                       { colspan: { default: 12, xs: 8 } },
@@ -369,65 +331,6 @@ export default function CampaignDetails() {
                     </Container>
                   </Grid>
 
-                  <Container
-                    header={<Header variant="h3">{t('inboundDetails.access.pinLabel')}</Header>}
-                  >
-                    {!showPinInput ? (
-                      <SpaceBetween size="s">
-                        <Box color="text-body-secondary">
-                          {t('inboundDetails.access.pinHiddenNote')}
-                        </Box>
-                        <Button
-                          onClick={() => {
-                            setShowPinInput(true)
-                            setPinError('')
-                            setPinMessage(null)
-                          }}
-                          iconName="key"
-                        >
-                          {t('inboundDetails.access.resetPinButton')}
-                        </Button>
-                      </SpaceBetween>
-                    ) : (
-                      <FormField errorText={pinError}>
-                        <SpaceBetween direction="horizontal" size="xs">
-                          <Input
-                            value={newPin}
-                            onChange={({ detail }) => {
-                              const numericValue = detail.value.replace(/\D/g, '').slice(0, 6)
-                              setNewPin(numericValue)
-                              if (pinError) setPinError('')
-                            }}
-                            placeholder={t('inboundDetails.access.newPinPlaceholder')}
-                            inputMode="numeric"
-                            invalid={!!pinError}
-                            onKeyDown={(e) => {
-                              if ((e as any).key === 'Enter' && newPin.length === 6) {
-                                handleSavePin()
-                              }
-                            }}
-                          />
-                          <Button
-                            variant="primary"
-                            onClick={handleSavePin}
-                            loading={pinSaving}
-                          >
-                            {t('inboundDetails.access.savePinButton')}
-                          </Button>
-                          <Button
-                            variant="link"
-                            onClick={() => {
-                              setShowPinInput(false)
-                              setNewPin('')
-                              setPinError('')
-                            }}
-                          >
-                            {t('inboundDetails.access.cancelButton')}
-                          </Button>
-                        </SpaceBetween>
-                      </FormField>
-                    )}
-                  </Container>
                 </SpaceBetween>
               )
             }] : [])

--- a/packages/web-app/src/pages/admin/CreateCampaign.tsx
+++ b/packages/web-app/src/pages/admin/CreateCampaign.tsx
@@ -41,7 +41,6 @@ export default function CreateCampaign() {
     ownerEmail: '',
     ownerName: '',
     campaignType: 'outbound' as 'outbound' | 'inbound',
-    campaignPin: '',
     prechatAgentConfigId: '',
   })
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({})
@@ -159,15 +158,6 @@ export default function CreateCampaign() {
       }
     }
 
-    // 인바운드 캠페인 PIN 검증
-    if (formData.campaignType === 'inbound') {
-      if (!formData.campaignPin.trim()) {
-        errors.campaignPin = t('adminCampaignCreate.validation.campaignPinRequired')
-      } else if (!/^\d{6}$/.test(formData.campaignPin)) {
-        errors.campaignPin = t('adminCampaignCreate.validation.campaignPinFormat')
-      }
-    }
-
     setValidationErrors(errors)
     return Object.keys(errors).length === 0
   }
@@ -190,7 +180,6 @@ export default function CreateCampaign() {
         endDate: formData.endDate,
         ownerId: formData.ownerId,
         campaignType: formData.campaignType,
-        ...(formData.campaignType === 'inbound' && { campaignPin: formData.campaignPin }),
         ...(formData.prechatAgentConfigId && {
           agentConfigurations: {
             prechat: formData.prechatAgentConfigId,
@@ -410,7 +399,6 @@ export default function CreateCampaign() {
                   setFormData(prev => ({
                     ...prev,
                     campaignType: detail.value as 'outbound' | 'inbound',
-                    campaignPin: '',
                   }))
                 }
                 items={[
@@ -427,23 +415,6 @@ export default function CreateCampaign() {
                 ]}
               />
             </FormField>
-
-            {formData.campaignType === 'inbound' && (
-              <FormField
-                label={t('adminCampaignCreate.form.campaignPinLabel')}
-                description={t('adminCampaignCreate.form.campaignPinDescription')}
-                errorText={validationErrors.campaignPin}
-                stretch
-              >
-                <Input
-                  value={formData.campaignPin}
-                  onChange={({ detail }) => updateFormData('campaignPin', detail.value)}
-                  placeholder={t('adminCampaignCreate.form.campaignPinPlaceholder')}
-                  type="number"
-                  invalid={!!validationErrors.campaignPin}
-                />
-              </FormField>
-            )}
 
             <FormField
               label={t('adminCampaignCreate.form.agentLabel')}

--- a/packages/web-app/src/pages/admin/EditCampaign.tsx
+++ b/packages/web-app/src/pages/admin/EditCampaign.tsx
@@ -48,7 +48,6 @@ export default function EditCampaign() {
     ownerEmail: '',
     ownerName: '',
     status: 'active' as Campaign['status'],
-    campaignPin: '',
     prechatAgentConfigId: '',
   })
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({})
@@ -93,7 +92,6 @@ export default function EditCampaign() {
         ownerEmail: campaignData.ownerEmail,
         ownerName: campaignData.ownerName,
         status: campaignData.status,
-        campaignPin: '',
         prechatAgentConfigId: (campaignData as any).agentConfigurations?.prechat || '',
       })
     } catch (err: any) {
@@ -158,13 +156,6 @@ export default function EditCampaign() {
       }
     }
 
-    // 인바운드 캠페인 PIN 검증 (입력된 경우에만)
-    if (campaign?.campaignType === 'inbound' && formData.campaignPin) {
-      if (!/^\d{6}$/.test(formData.campaignPin)) {
-        errors.campaignPin = t('adminCampaignEdit.validation.campaignPinFormat')
-      }
-    }
-
     setValidationErrors(errors)
     return Object.keys(errors).length === 0
   }
@@ -187,9 +178,6 @@ export default function EditCampaign() {
         endDate: formData.endDate,
         ownerId: formData.ownerId,
         status: formData.status,
-        ...(campaign?.campaignType === 'inbound' && formData.campaignPin
-          ? { campaignPin: formData.campaignPin }
-          : {}),
         ...(formData.prechatAgentConfigId && {
           agentConfigurations: {
             prechat: formData.prechatAgentConfigId,
@@ -437,23 +425,6 @@ export default function EditCampaign() {
                 placeholder={t('adminCampaignEdit.form.statusPlaceholder')}
               />
             </FormField>
-
-            {campaign?.campaignType === 'inbound' && (
-              <FormField
-                label={t('adminCampaignEdit.form.campaignPinLabel')}
-                description={t('adminCampaignEdit.form.campaignPinDescription')}
-                errorText={validationErrors.campaignPin}
-                stretch
-              >
-                <Input
-                  value={formData.campaignPin}
-                  onChange={({ detail }) => updateFormData('campaignPin', detail.value)}
-                  placeholder={t('adminCampaignEdit.form.campaignPinPlaceholder')}
-                  type="number"
-                  invalid={!!validationErrors.campaignPin}
-                />
-              </FormField>
-            )}
 
             <FormField
               label={t('adminCampaignEdit.form.agentLabel')}

--- a/packages/web-app/src/pages/customer/InboundEntry.tsx
+++ b/packages/web-app/src/pages/customer/InboundEntry.tsx
@@ -15,10 +15,10 @@ import {
 } from '@cloudscape-design/components';
 import { useI18n } from '../../i18n';
 import { inboundApi } from '../../services/api';
-import { storePinForSession, storePrivacyConsentForSession } from '../../utils/sessionStorage';
+import { storePrivacyConsentForSession } from '../../utils/sessionStorage';
 import type { InboundCampaignInfo, CreateInboundSessionRequest } from '../../types';
 
-type Step = 'loading' | 'pin' | 'pii' | 'error';
+type Step = 'loading' | 'pii' | 'error';
 
 export default function InboundEntry() {
   const { campaignCode } = useParams<{ campaignCode: string }>();
@@ -29,8 +29,6 @@ export default function InboundEntry() {
   const [campaign, setCampaign] = useState<InboundCampaignInfo | null>(null);
   const [errorMsg, setErrorMsg] = useState('');
   const [submitting, setSubmitting] = useState(false);
-  const [pin, setPin] = useState('');
-  const [pinError, setPinError] = useState('');
   const [formData, setFormData] = useState({
     customerName: '',
     customerEmail: '',
@@ -52,7 +50,7 @@ export default function InboundEntry() {
     try {
       const info = await inboundApi.getCampaignInfo(campaignCode!);
       setCampaign(info);
-      setStep('pin');
+      setStep('pii');
     } catch (err: any) {
       const status = err?.statusCode;
       if (status === 404) {
@@ -64,15 +62,6 @@ export default function InboundEntry() {
       }
       setStep('error');
     }
-  };
-
-  const handlePinSubmit = () => {
-    if (!pin || !/^\d{6}$/.test(pin)) {
-      setPinError(t('inbound.pin.invalidFormat'));
-      return;
-    }
-    setPinError('');
-    setStep('pii');
   };
 
   const validatePii = (): boolean => {
@@ -101,14 +90,12 @@ export default function InboundEntry() {
         customerEmail: formData.customerEmail.trim(),
         customerCompany: formData.customerCompany.trim(),
         customerPhone: formData.customerPhone.trim(),
-        pinNumber: pin,
       };
       const result = await inboundApi.createSession(campaignCode!, req);
       if (result.csrfToken) {
         localStorage.setItem(`csrf_${result.sessionId}`, result.csrfToken);
       }
-      // PIN과 개인정보 동의를 sessionStorage에 저장 → CustomerChat WSS 연결에 사용
-      storePinForSession(result.sessionId, pin);
+      // 개인정보 동의를 sessionStorage에 저장
       storePrivacyConsentForSession(result.sessionId);
       navigate(`/customer/${result.sessionId}`);
     } catch (err: any) {
@@ -120,11 +107,7 @@ export default function InboundEntry() {
 
   const handleSubmitError = (err: any) => {
     const status = err?.statusCode;
-    if (status === 401) {
-      setErrorMsg(t('inbound.error.invalidPin'));
-      setStep('pin');
-      setPin('');
-    } else if (status === 403) {
+    if (status === 403) {
       setErrorMsg(t('inbound.error.campaignInactive'));
     } else {
       setErrorMsg(t('inbound.error.createFailed'));
@@ -183,9 +166,6 @@ export default function InboundEntry() {
     <Form
       actions={
         <SpaceBetween direction="horizontal" size="xs">
-          <Button variant="link" onClick={() => setStep('pin')}>
-            {t('inbound.pii.backButton')}
-          </Button>
           <Button variant="primary" onClick={handlePiiSubmit} loading={submitting}>
             {t('inbound.pii.submitButton')}
           </Button>
@@ -223,35 +203,6 @@ export default function InboundEntry() {
         </Header>
         {errorMsg && (
           <Alert type="error" dismissible onDismiss={() => setErrorMsg('')}>{errorMsg}</Alert>
-        )}
-        {step === 'pin' && (
-          <Form
-            actions={<Button variant="primary" onClick={handlePinSubmit}>{t('inbound.pin.submitButton')}</Button>}
-          >
-            <FormField
-              label={t('inbound.pin.label')}
-              description={t('inbound.pin.description')}
-              errorText={pinError}
-            >
-              <Input
-                value={pin}
-                onChange={({ detail }) => {
-                  // 숫자만 허용하고 최대 6자리까지만
-                  const numericValue = detail.value.replace(/\D/g, '').slice(0, 6);
-                  setPin(numericValue);
-                  if (pinError) setPinError('');
-                }}
-                placeholder={t('inbound.pin.placeholder')}
-                inputMode="numeric"
-                invalid={!!pinError}
-                onKeyDown={(e) => {
-                  if ((e as any).key === 'Enter' && pin.length === 6) {
-                    handlePinSubmit();
-                  }
-                }}
-              />
-            </FormField>
-          </Form>
         )}
         {step === 'pii' && renderPiiForm()}
       </SpaceBetween>

--- a/packages/web-app/src/types/index.ts
+++ b/packages/web-app/src/types/index.ts
@@ -157,7 +157,6 @@ export interface CreateInboundSessionRequest {
   customerEmail: string;
   customerCompany: string;
   customerPhone: string;
-  pinNumber: string;
 }
 
 // 인바운드 세션 생성 응답


### PR DESCRIPTION
Remove PIN input step and verification from inbound campaign flow:
- Frontend: Remove PIN step, state, UI, error handling from InboundEntry.tsx
- Frontend: Remove pinNumber from CreateInboundSessionRequest type
- Frontend: Skip PIN param in WebSocket URL for inbound sessions
- Backend: Remove PIN validation from inbound_session_handler.py
- WebSocket: Remove _verify_inbound_pin(), allow inbound sessions without PIN

Outbound campaign PIN authentication remains unchanged. This is a temporary patch - restore via git revert if needed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
